### PR TITLE
Updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Kubernetes (K8S) Spot Instance Notification
 
-This service will run as DaemonSet within your K8s cluster running on AWS Spot Instance.
+This service will run as DaemonSet within your K8s cluster running on AWS Spot Instance, it watches the AWS metadata service when running on Spot Instances.
 
 AWS Spot instance receives termination notice via the [instance meta data](https://aws.amazon.com/blogs/aws/new-ec2-spot-instance-termination-notices/), that field will become available when the instance has been marked for termination, and will contain the time when a shutdown signal will be sent to the instance’s operating system.
 
-This service will notify you via Slack that an Spot instance will be taken out of service/terminated.
+This service will notify you via Slack that an Spot instance will be taken out of service.
 
 ## Prerequisites
 
@@ -18,6 +18,17 @@ This service will notify you via Slack that an Spot instance will be taken out o
 - SLACK_API_TOKEN
 - SLACK_CHANNEL
 
+## Deployment
+
+To deoloy this in your cluster:
+
+> Update `kustomization.yml` to deploy in a different `namespace`,
+> otherwise this will be deployed to `default` namespace
+
+```shell
+kubectl apply -k deployment/
+```
+
 ## TODO
 
- [ ] Drain Node
+- [ ] Drain Node

--- a/deployment/daemonset.yml
+++ b/deployment/daemonset.yml
@@ -12,7 +12,8 @@ spec:
       labels:
         app: spot-termination-notice
     spec:
-      serviceAccountName: spot-termination-notice
+      # future proof: create service account for node draining
+      # serviceAccountName: spot-termination-notice
       containers:
       - name: spot-termination-notice
         image: saidsef/k8s-spot-termination-notice:latest
@@ -64,5 +65,3 @@ spec:
               command:
                 - pgrep
                 - python
-      nodeSelector:
-        lifecycle: Ec2Spot


### PR DESCRIPTION
In this PR we've:

 - 8f1b310 bugfix: commented out service account - this will be re-enabled when node drain is implemented
 - 7750ec4 added K8s deployment info